### PR TITLE
REDDEV-612 patch edit summary

### DIFF
--- a/js-tests/components/ReportCounts_test.js
+++ b/js-tests/components/ReportCounts_test.js
@@ -85,7 +85,7 @@ describe('ReportCounts.vue', () => {
     const fillForm = async (wrapper) => {
       wrapper.find('input[name=title]').setValue('Title');
       wrapper.findAll('select[name=reportId] option').at(1).setSelected();
-      await waitForSelector(wrapper, '#strategy0:enabled');
+      await waitForSelector(wrapper, '[name="strategy"]:first-child:enabled');
       wrapper.findAll('input[name=strategy]').at(0).setChecked();
     };
 

--- a/js-tests/components/ReportCounts_test.js
+++ b/js-tests/components/ReportCounts_test.js
@@ -85,8 +85,8 @@ describe('ReportCounts.vue', () => {
     const fillForm = async (wrapper) => {
       wrapper.find('input[name=title]').setValue('Title');
       wrapper.findAll('select[name=reportId] option').at(1).setSelected();
-      await waitForSelector(wrapper, '[name="strategy"]:first-child:enabled');
-      wrapper.findAll('input[name=strategy]').at(0).setChecked();
+      await waitForSelector(wrapper, '[data-description="strategy-input"]:first-child:enabled');
+      wrapper.findAll('input[data-description="strategy-input"]').at(0).setChecked();
     };
 
     beforeEach(async () => {

--- a/js-tests/components/ReportSummaryForm_test.js
+++ b/js-tests/components/ReportSummaryForm_test.js
@@ -12,7 +12,7 @@ import {
 } from '../test-utils';
 
 describe('ReportSummaryForm.vue', () => {
-  let mockProvide, wrapper;
+  let mockProvide, wrapper, id;
 
   beforeEach(async () => {
     mockProvide = createProvideObject();
@@ -23,6 +23,8 @@ describe('ReportSummaryForm.vue', () => {
     wrapper = shallowMount(ReportSummaryForm, {
       provide: mockProvide
     });
+
+    id = wrapper.vm.model.id;
 
     await wrapper.vm.reportPromise;
   });
@@ -48,12 +50,12 @@ describe('ReportSummaryForm.vue', () => {
 
     it('renders form and title field', () => {
       expect(wrapper.findAll('.report-summary-form').length).toEqual(1);
-      expect(wrapper.findAll('#title').length).toEqual(1);
+      expect(wrapper.findAll(`#title${id}`).length).toEqual(1);
     });
 
     it('renders report drop-down', () => {
-      expect(wrapper.findAll('#reportId').length).toEqual(1);
-      const options = wrapper.findAll('#reportId option');
+      expect(wrapper.findAll(`#reportId${id}`).length).toEqual(1);
+      const options = wrapper.findAll(`#reportId${id} option`);
       expect(options.length).toEqual(3);
       expect(options.at(1).attributes().value).toEqual('2');
       expect(options.at(1).text()).toEqual('Report 2');
@@ -64,9 +66,9 @@ describe('ReportSummaryForm.vue', () => {
       expect(strategy.length).toEqual(2);
       const radio1 = strategy.at(0);
       const radio2 = strategy.at(1);
-      expect(radio1.attributes().id).toEqual('strategy0');
+      expect(radio1.attributes().id).toEqual(`strategy0${id}`);
       expect(radio1.attributes().value).toEqual(STRATEGY.TOTAL);
-      expect(radio2.attributes().id).toEqual('strategy1');
+      expect(radio2.attributes().id).toEqual(`strategy1${id}`);
       expect(radio2.attributes().value).toEqual(STRATEGY.ITEMIZED);
     });
 
@@ -79,9 +81,9 @@ describe('ReportSummaryForm.vue', () => {
         reportFields: mockReportFields
       });
 
-      expect(wrapper.findAll('#bucketBy').length).toEqual(1);
+      expect(wrapper.findAll(`#bucketBy${id}`).length).toEqual(1);
 
-      const options = wrapper.findAll('#bucketBy option');
+      const options = wrapper.findAll(`#bucketBy${id} option`);
       expect(options.length).toEqual(3);
 
       expect(options.at(0).text()).toEqual('field_1 "Field 1"');
@@ -147,7 +149,7 @@ describe('ReportSummaryForm.vue', () => {
     wrapper.find('.btn-primary').trigger('click');
     expect(wrapper.vm.errorCount).toEqual(1);
     expect(wrapper.vm.errors.reportId).toEqual(messages.reportRequired);
-    expect(wrapper.findAll('#bucketBy').length).toEqual(0);
+    expect(wrapper.findAll(`#bucketBy${id}`).length).toEqual(0);
 
     // Require a bucketBy field on strategy='itemized'
     wrapper.vm.model.title = 'Itemized Results';
@@ -157,8 +159,8 @@ describe('ReportSummaryForm.vue', () => {
     wrapper.find('.btn-primary').trigger('click');
     expect(wrapper.vm.errorCount).toEqual(1);
     expect(wrapper.vm.errors.bucketBy).toEqual(messages.bucketByRequired);
-    expect(wrapper.findAll('#bucketBy').length).toEqual(1);
-    expect(wrapper.findAll('#bucketBy').isVisible()).toEqual(true);
+    expect(wrapper.findAll(`#bucketBy${id}`).length).toEqual(1);
+    expect(wrapper.findAll(`#bucketBy${id}`).isVisible()).toEqual(true);
   });
 
   it('checks for fields to group by and displays error message accordingly', () => {
@@ -249,7 +251,7 @@ describe('ReportSummaryForm.vue', () => {
     wrapper.vm.reportFields = mockReportFields;
 
     // Select one of the bucketBy options
-    wrapper.findAll('#bucketBy option').at(0).setSelected();
+    wrapper.findAll(`#bucketBy${id} option`).at(0).setSelected();
 
     // Switch to a report that does not have reportFields
     wrapper.vm.model.reportId = 11;
@@ -259,7 +261,6 @@ describe('ReportSummaryForm.vue', () => {
     expect(wrapper.vm.errors.strategy).toEqual(messages.noBucketByFields);
 
     // The bucketBy field should be reset
-    expect(wrapper.vm.model.bucketBy).toBeNull();
     expect(wrapper.vm.errors.bucketBy).not.toEqual(messages.bucketByRequired);
 
     // Try to submit the form
@@ -268,7 +269,6 @@ describe('ReportSummaryForm.vue', () => {
     // Ensure that the previously selected bucketBy field is not selected which
     // prevents the form from being submitted with an invalid bucketBy value.
     expect(wrapper.vm.errors.strategy).toEqual(messages.noBucketByFields);
-    expect(wrapper.vm.model.bucketBy).toBeNull();
   });
 
   it('hides form title', async () => {

--- a/js-tests/components/ReportSummaryForm_test.js
+++ b/js-tests/components/ReportSummaryForm_test.js
@@ -62,7 +62,7 @@ describe('ReportSummaryForm.vue', () => {
     });
 
     it('renders radio buttons for the strategy values', () => {
-      const strategy = wrapper.findAll('input[name="strategy"]');
+      const strategy = wrapper.findAll(`input[data-description="strategy-input"]`);
       expect(strategy.length).toEqual(2);
       const radio1 = strategy.at(0);
       const radio2 = strategy.at(1);
@@ -233,7 +233,7 @@ describe('ReportSummaryForm.vue', () => {
   it('disables strategy radio buttons unless a report is selected', () => {
     wrapper.vm.model.title = 'Report Title';
 
-    const radios = wrapper.findAll('input[name="strategy"]');
+    const radios = wrapper.findAll(`input[data-description="strategy-input"]`);
     expect(radios.at(0).attributes().disabled).toBeTruthy();
     expect(radios.at(1).attributes().disabled).toBeTruthy();
 
@@ -291,5 +291,12 @@ describe('ReportSummaryForm.vue', () => {
     });
     await wrapper.vm.reportPromise;
     expect(wrapper.findAll('.card-header').length).toEqual(1);
+  });
+
+  it('builds a field id', () => {
+    const fieldName = 'title';
+    const fieldId = wrapper.vm.fieldId(fieldName);
+    const expectedFieldId = `${fieldName}${wrapper.vm.model.id}`;
+    expect(fieldId).toEqual(expectedFieldId);
   });
 });

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -23,8 +23,7 @@
           <a class="delete" v-if="canDelete" @click="deleteSummary">Delete <i class="far fa-trash-alt"></i></a>
         </div>
         <div v-if="editing && canEdit" class="edit-form container">
-          <ReportSummaryForm :key="model.id"
-                             :hideFormTitle=true
+          <ReportSummaryForm :hideFormTitle=true
                              :initial-state="model.config"
                              @reportSummarySaved="forwardUpdatedSummary"
                              @formCanceled="cancelEdit" />

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -23,7 +23,8 @@
           <a class="delete" v-if="canDelete" @click="deleteSummary">Delete <i class="far fa-trash-alt"></i></a>
         </div>
         <div v-if="editing && canEdit" class="edit-form container">
-          <ReportSummaryForm :hideFormTitle=true
+          <ReportSummaryForm :key="model.id"
+                             :hideFormTitle=true
                              :initial-state="model.config"
                              @reportSummarySaved="forwardUpdatedSummary"
                              @formCanceled="cancelEdit" />

--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -16,8 +16,8 @@
       </ul>
       <div class="row form-group">
         <div class="col">
-          <label :for="'title' + model.id">Report Count Title</label>
-          <input :id="'title' + model.id" name="title" v-model.trim="model.title" type="text" class="form-control" :class="{ 'is-invalid': errors.title }">
+          <label :for="fieldId('title')">Report Count Title</label>
+          <input :id="fieldId('title')" name="title" v-model.trim="model.title" type="text" class="form-control" :class="{ 'is-invalid': errors.title }">
           <div class="invalid-feedback" v-if="errors.title">
             {{ errors.title }}
           </div>
@@ -25,8 +25,8 @@
       </div>
       <div class="row form-group">
         <div class="col">
-          <label :for="'reportId' + model.id">Select a Report</label>
-          <select :id="'reportId' + model.id" name="reportId" v-model="model.reportId" class="form-control" :class="{ 'is-invalid': errors.reportId }" @change="loadReportFields()">
+          <label :for="fieldId('reportId')">Select a Report</label>
+          <select :id="fieldId('reportId')" name="reportId" v-model="model.reportId" class="form-control" :class="{ 'is-invalid': errors.reportId }" @change="loadReportFields()">
             <option v-for="report in reports" :key="report.reportId" :value="report.reportId">{{ report.title }}</option>
           </select>
           <div class="invalid-feedback" v-if="errors.reportId">
@@ -38,8 +38,8 @@
         <div class="col strategy-controls">
           <label>Summary Type</label>
           <div class="form-check" v-for="(strategyVal, i) in strategies" :key="strategyVal">
-            <input class="form-check-input" :class="{ 'is-invalid': errors.strategy }" :id="'strategy' + i + model.id" name="strategy" v-model="model.strategy" :value="strategyVal" type="radio" :disabled="!reportSelected">
-            <label class="form-check-label" :for="'strategy' + i + model.id">{{ strategyVal }}</label>
+            <input class="form-check-input" :class="{ 'is-invalid': errors.strategy }" :id="fieldId('strategy' + i)" :name="fieldId('strategy' + i)" data-description="strategy-input" v-model="model.strategy" :value="strategyVal" type="radio" :disabled="!reportSelected">
+            <label class="form-check-label" :for="fieldId('strategy' + i)">{{ strategyVal }}</label>
           </div>
           <div class="invalid-feedback" v-if="errors.strategy">
             {{ errors.strategy }}
@@ -49,7 +49,7 @@
       <div class="row form-group" v-if="showBucketByFields">
         <div class="col">
           <label>Field to Group Results</label>
-          <select :id="'bucketBy' + model.id" name="bucketBy" v-model="model.bucketBy" class="form-control" :class="{ 'is-invalid': errors.bucketBy }">
+          <select :id="fieldId('bucketBy')" name="bucketBy" v-model="model.bucketBy" class="form-control" :class="{ 'is-invalid': errors.bucketBy }">
             <option v-for="field in reportFields" :key="field.field_name" :value="field.field_name">{{ field.field_name }} "{{ field.field_label }}"</option>
           </select>
           <div class="invalid-feedback" v-if="errors.bucketBy">
@@ -292,6 +292,18 @@ export default {
      */
     loadReportFields() {
       this.reportFieldsPromise = this.fetchReportFields();
+    },
+
+    /**
+     * There can be multiple instances of the `ReportSummaryForm` on a page.
+     * This function takes a field name and appends the `model.id` to ensure
+     * the value will be unique across all forms.
+     * @param {String} name - The field name.
+     * @return {String} The field id for the given name.
+     */
+    fieldId(name) {
+      const { model } = this;
+      return `${name}${model.id}`;
     }
   },
 

--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -16,8 +16,8 @@
       </ul>
       <div class="row form-group">
         <div class="col">
-          <label for="title">Report Count Title</label>
-          <input id="title" name="title" v-model.trim="model.title" type="text" class="form-control" :class="{ 'is-invalid': errors.title }">
+          <label :for="'title' + model.id">Report Count Title</label>
+          <input :id="'title' + model.id" name="title" v-model.trim="model.title" type="text" class="form-control" :class="{ 'is-invalid': errors.title }">
           <div class="invalid-feedback" v-if="errors.title">
             {{ errors.title }}
           </div>
@@ -25,8 +25,8 @@
       </div>
       <div class="row form-group">
         <div class="col">
-          <label for="reportId">Select a Report</label>
-          <select id="reportId" name="reportId" v-model="model.reportId" class="form-control" :class="{ 'is-invalid': errors.reportId }" @change="loadReportFields()">
+          <label :for="'reportId' + model.id">Select a Report</label>
+          <select :id="'reportId' + model.id" name="reportId" v-model="model.reportId" class="form-control" :class="{ 'is-invalid': errors.reportId }" @change="loadReportFields()">
             <option v-for="report in reports" :key="report.reportId" :value="report.reportId">{{ report.title }}</option>
           </select>
           <div class="invalid-feedback" v-if="errors.reportId">
@@ -36,10 +36,10 @@
       </div>
       <div class="row form-group">
         <div class="col strategy-controls">
-          <label for="strategy">Summary Type</label>
+          <label>Summary Type</label>
           <div class="form-check" v-for="(strategyVal, i) in strategies" :key="strategyVal">
-            <input class="form-check-input" :class="{ 'is-invalid': errors.strategy }" :id="'strategy' + i" name="strategy" v-model="model.strategy" :value="strategyVal" type="radio" :disabled="!reportSelected">
-            <label class="form-check-label" :for="'strategy' + i">{{ strategyVal }}</label>
+            <input class="form-check-input" :class="{ 'is-invalid': errors.strategy }" :id="'strategy' + i + model.id" name="strategy" v-model="model.strategy" :value="strategyVal" type="radio" :disabled="!reportSelected">
+            <label class="form-check-label" :for="'strategy' + i + model.id">{{ strategyVal }}</label>
           </div>
           <div class="invalid-feedback" v-if="errors.strategy">
             {{ errors.strategy }}
@@ -48,8 +48,8 @@
       </div>
       <div class="row form-group" v-if="showBucketByFields">
         <div class="col">
-          <label for="bucketBy">Field to Group Results</label>
-          <select id="bucketBy" name="bucketBy" v-model="model.bucketBy" class="form-control" :class="{ 'is-invalid': errors.bucketBy }">
+          <label>Field to Group Results</label>
+          <select :id="'bucketBy' + model.id" name="bucketBy" v-model="model.bucketBy" class="form-control" :class="{ 'is-invalid': errors.bucketBy }">
             <option v-for="field in reportFields" :key="field.field_name" :value="field.field_name">{{ field.field_name }} "{{ field.field_label }}"</option>
           </select>
           <div class="invalid-feedback" v-if="errors.bucketBy">
@@ -310,7 +310,7 @@ export default {
      */
     reportFields() {
       const { model } = this;
-      model.bucketBy = null;
+      model.bucketBy = model.bucketBy || null;
       this.validateItemization();
     }
   },

--- a/js/report-summary-config.js
+++ b/js/report-summary-config.js
@@ -12,8 +12,8 @@ export default class ReportSummaryConfig {
    * @return {ReportSummaryConfig} a new object with the same property values
    */
   static fromObject(other) {
-    const { id, title, reportId, strategy, bucketBy } = other;
-    return new ReportSummaryConfig(id, title, reportId, strategy, bucketBy);
+    const { id, title, reportId, strategy, bucketBy, reportExists } = other;
+    return new ReportSummaryConfig(id, title, reportId, strategy, bucketBy, reportExists);
   }
 
   /**
@@ -25,12 +25,15 @@ export default class ReportSummaryConfig {
    *   constants from `report-strategy.js`. Defaults to STRATEGY.TOTAL.
    * @param {String} bucketBy - field to bucket itemized counts by. Only valid when `strategy`
    *   is `STRATEGY.ITEMIZED`. Defaults to null.
+   * @param {Boolean} reportExists - `true` if the report exists, otherwise `false` indicating
+   *   the report is inaccessible or deleted.
    */
-  constructor(id, title, reportId, strategy, bucketBy) {
+  constructor(id, title, reportId, strategy, bucketBy, reportExists) {
     this.id = id || uuid();
     this.title = title || '';
     this.reportId = reportId || null;
     this.strategy = strategy || STRATEGY.TOTAL;
     this.bucketBy = bucketBy || null;
+    this.reportExists = reportExists || false;
   }
 }

--- a/js/report-summary-model.js
+++ b/js/report-summary-model.js
@@ -59,7 +59,7 @@ export default class ReportSummaryModel {
    * @property {ReportSummaryConfig} config - configuration for this summary
    */
   get config() {
-    const { id, title, reportId, strategy, bucketBy } = this;
-    return new ReportSummaryConfig(id, title, reportId, strategy, bucketBy);
+    const { id, title, reportId, strategy, bucketBy, reportExists } = this;
+    return new ReportSummaryConfig(id, title, reportId, strategy, bucketBy, reportExists);
   }
 }


### PR DESCRIPTION
Ensure persisted group-by field is selected when editing a summary. The config was missing the "reportExists" property.

Update unit tests.

There's another non-breaking issue that should probably be resolved, but I'll do that in another PR or file an issue. If two edit forms are open at the same time, the first will have it's strategy radio un-selected and vice versa. The form can still be saved, and if itemized, the bucketBy value is still persisted correctly. The screen shot below illustrates the issue. "Discontinued" was opened second and the radio for "Summary Type" in the "Enrolled" form was deselected. There might be an easy fix, but I'm not seeing it.

![screen shot 2019-01-15 at 14 02 15](https://user-images.githubusercontent.com/273863/51212793-3dc28a80-18ce-11e9-8c0d-c017c7069ffb.png)