### PR TITLE
REDDEV-595 permissions

### DIFF
--- a/ReportCounts.php
+++ b/ReportCounts.php
@@ -9,4 +9,12 @@ use ExternalModules\ExternalModules;
 // Declare your module class, which must extend AbstractExternalModule
 class ReportCounts extends AbstractExternalModule {
 
+  /**
+   * Override to allow anyone with project access to be able to view report counts. The
+   * user will need `Add/Edit/Organize Reports` rights in order to modify summaries.
+   */
+  public function redcap_module_link_check_display($project_id, $link) {
+    return $link;
+  }
+
 }

--- a/js-tests/components/ReportCounts_test.js
+++ b/js-tests/components/ReportCounts_test.js
@@ -5,7 +5,7 @@ import ReportCountsHelp from '@/components/ReportCountsHelp';
 import ReportSummaryModel from '@/report-summary-model';
 import { STRATEGY } from '@/report-strategy';
 
-import { createProvideObject, waitForSelector, buildMockSecurityConfig } from '../test-utils';
+import { createProvideObject, waitForSelector, mockSecurityConfig } from '../test-utils';
 
 const aboutTextSelector = '#about-report-counts-module';
 
@@ -210,7 +210,7 @@ describe('ReportCounts.vue', () => {
             return Promise.resolve([]);
           },
           fetchSecurityConfig() {
-            return Promise.resolve(buildMockSecurityConfig(true));
+            return Promise.resolve(mockSecurityConfig(true));
           }
         }
       };
@@ -327,7 +327,7 @@ describe('ReportCounts.vue', () => {
       beforeEach(async () => {
         mockProvide = createProvideObject();
         spyOn(mockProvide.dataService, 'fetchSecurityConfig')
-          .and.returnValue(Promise.resolve(buildMockSecurityConfig(false)));
+          .and.returnValue(Promise.resolve(mockSecurityConfig(false)));
 
         wrapper = mount(ReportCounts, {
           provide: mockProvide
@@ -345,7 +345,7 @@ describe('ReportCounts.vue', () => {
       beforeEach(async () => {
         mockProvide = createProvideObject();
         spyOn(mockProvide.dataService, 'fetchSecurityConfig')
-          .and.returnValue(Promise.resolve(buildMockSecurityConfig(true)));
+          .and.returnValue(Promise.resolve(mockSecurityConfig(true)));
 
         wrapper = mount(ReportCounts, {
           provide: mockProvide

--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -8,7 +8,7 @@ import { MISSING } from '@/constants';
 import shuffle from 'lodash/shuffle';
 import { messages } from '@/components/ReportSummary';
 
-import { createProvideObject, buildMockSecurityConfig } from '../test-utils';
+import { createProvideObject, mockSecurityConfig } from '../test-utils';
 
 const selectors = {
   metadata: '.summary-metadata li',
@@ -16,7 +16,7 @@ const selectors = {
 };
 
 describe('ReportSummary.vue', () => {
-  const securityConfig = buildMockSecurityConfig(true);
+  const securityConfig = mockSecurityConfig(true);
 
   describe('For total strategy', () => {
     let wrapper;
@@ -411,7 +411,7 @@ describe('ReportSummary.vue', () => {
           provide: createProvideObject(),
           propsData: {
             model,
-            securityConfig: buildMockSecurityConfig(false)
+            securityConfig: mockSecurityConfig(false)
           }
         });
       });
@@ -428,7 +428,7 @@ describe('ReportSummary.vue', () => {
           provide: createProvideObject(),
           propsData: {
             model,
-            securityConfig: buildMockSecurityConfig(true)
+            securityConfig: mockSecurityConfig(true)
           }
         });
       });

--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -8,7 +8,7 @@ import { MISSING } from '@/constants';
 import shuffle from 'lodash/shuffle';
 import { messages } from '@/components/ReportSummary';
 
-import { createProvideObject } from '../test-utils';
+import { createProvideObject, buildMockSecurityConfig } from '../test-utils';
 
 const selectors = {
   metadata: '.summary-metadata li',
@@ -16,6 +16,8 @@ const selectors = {
 };
 
 describe('ReportSummary.vue', () => {
+  const securityConfig = buildMockSecurityConfig(true);
+
   describe('For total strategy', () => {
     let wrapper;
 
@@ -30,7 +32,8 @@ describe('ReportSummary.vue', () => {
 
       wrapper = shallowMount(ReportSummary, {
         propsData: {
-          model
+          model,
+          securityConfig
         }
       });
     });
@@ -68,7 +71,8 @@ describe('ReportSummary.vue', () => {
 
       wrapper = shallowMount(ReportSummary, {
         propsData: {
-          model
+          model,
+          securityConfig
         }
       });
     });
@@ -135,7 +139,8 @@ describe('ReportSummary.vue', () => {
 
       const wrapper = shallowMount(ReportSummary, {
         propsData: {
-          model
+          model,
+          securityConfig
         }
       });
       expect(wrapper.vm.hasMissingValue).toEqual(true);
@@ -160,7 +165,8 @@ describe('ReportSummary.vue', () => {
 
       const wrapper = shallowMount(ReportSummary, {
         propsData: {
-          model
+          model,
+          securityConfig
         }
       });
 
@@ -199,7 +205,8 @@ describe('ReportSummary.vue', () => {
       wrapper = mount(ReportSummary, {
         provide: createProvideObject(),
         propsData: {
-          model
+          model,
+          securityConfig
         }
       });
     });
@@ -259,7 +266,8 @@ describe('ReportSummary.vue', () => {
 
       wrapper = shallowMount(ReportSummary, {
         propsData: {
-          model
+          model,
+          securityConfig
         }
       });
     });
@@ -328,7 +336,8 @@ describe('ReportSummary.vue', () => {
       wrapper = mount(ReportSummary, {
         provide: createProvideObject(),
         propsData: {
-          model
+          model,
+          securityConfig
         }
       });
     });
@@ -363,7 +372,8 @@ describe('ReportSummary.vue', () => {
       wrapper = mount(ReportSummary, {
         provide: createProvideObject(),
         propsData: {
-          model
+          model,
+          securityConfig
         }
       });
     });
@@ -377,6 +387,56 @@ describe('ReportSummary.vue', () => {
       expect(wrapper.findAll('.summary-controls').length).toEqual(1);
       expect(wrapper.findAll('.card-title').length).toEqual(1);
       expect(wrapper.find('.card-title').text()).toEqual('Original Title');
+    });
+  });
+
+  describe('security configuration', () => {
+    let wrapper, model;
+
+    beforeEach(() => {
+      model = ReportSummaryModel.fromObject({
+        id: '68d41098-f49a-4241-8014-ab519224fda7',
+        title: 'Original Title',
+        reportId: 3,
+        totalRecords: 8,
+        strategy: STRATEGY.TOTAL,
+        bucketByFieldExists: false,
+        reportExists: true
+      });
+    });
+
+    describe('basic user - does not have access to modify counts', () => {
+      beforeEach(() => {
+        wrapper = mount(ReportSummary, {
+          provide: createProvideObject(),
+          propsData: {
+            model,
+            securityConfig: buildMockSecurityConfig(false)
+          }
+        });
+      });
+
+      it('hides summary controls and drag handle', () => {
+        expect(wrapper.findAll('.summary-controls').length).toEqual(0);
+        expect(wrapper.findAll('.drag-handle').length).toEqual(0);
+      });
+    });
+
+    describe('admin user - has access to modify counts', () => {
+      beforeEach(() => {
+        wrapper = mount(ReportSummary, {
+          provide: createProvideObject(),
+          propsData: {
+            model,
+            securityConfig: buildMockSecurityConfig(true)
+          }
+        });
+      });
+
+      it('shows summary controls and drag handle', () => {
+        expect(wrapper.findAll('.summary-controls').length).toEqual(1);
+        expect(wrapper.findAll('.drag-handle').length).toEqual(1);
+      });
     });
   });
 });

--- a/js-tests/test-utils.js
+++ b/js-tests/test-utils.js
@@ -22,11 +22,11 @@ export const mockReportFields = [
  * Function to build response from the data service's `fetchSecurityConfig` method.
  * @param {Boolean} hasReportsRights - true to indicate the user has reports rights
  */
-export const buildMockSecurityConfig = function(hasReportsRights=false) {
+export function mockSecurityConfig(hasReportsRights=false) {
   return {
     hasReportsRights: hasReportsRights
-  }
-};
+  };
+}
 
 /**
  * Constructs an object that mocks dependencies injected into components. For use with
@@ -61,7 +61,7 @@ export function createProvideObject() {
       },
 
       fetchSecurityConfig() {
-        return Promise.resolve(buildMockSecurityConfig(true));
+        return Promise.resolve(mockSecurityConfig(true));
       }
     }
   };

--- a/js-tests/test-utils.js
+++ b/js-tests/test-utils.js
@@ -19,6 +19,16 @@ export const mockReportFields = [
 ];
 
 /**
+ * Function to build response from the data service's `fetchSecurityConfig` method.
+ * @param {Boolean} hasReportsRights - true to indicate the user has reports rights
+ */
+export const buildMockSecurityConfig = function(hasReportsRights=false) {
+  return {
+    hasReportsRights: hasReportsRights
+  }
+};
+
+/**
  * Constructs an object that mocks dependencies injected into components. For use with
  * the `mount` and `shallowMount` test renderers.
  *
@@ -48,6 +58,10 @@ export function createProvideObject() {
 
       getReportFields() {
         return Promise.resolve(mockReportFields);
+      },
+
+      fetchSecurityConfig() {
+        return Promise.resolve(buildMockSecurityConfig(true));
       }
     }
   };

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -13,16 +13,17 @@
           <h3 class="card-title mb-1 float-left">{{ model.title }}</h3>
           <div class="drag-handle float-right text-muted"
                title="Drag to Reorder"
+               v-if="securityConfig.hasReportsRights"
                @mousedown="enableDrag"
                @mouseup="disableDrag">
             <i class="fa fa-arrows-alt"></i>
           </div>
         </div>
-        <div class="summary-controls mb-1">
-          <a class="edit" v-if="canEdit" @click="editSummary">Edit <i class="fa fa-edit"></i></a>
-          <a class="delete" v-if="canDelete" @click="deleteSummary">Delete <i class="far fa-trash-alt"></i></a>
+        <div class="summary-controls mb-1" v-if="securityConfig.hasReportsRights">
+          <a class="edit" @click="editSummary">Edit <i class="fa fa-edit"></i></a>
+          <a class="delete" @click="deleteSummary">Delete <i class="far fa-trash-alt"></i></a>
         </div>
-        <div v-if="editing && canEdit" class="edit-form container">
+        <div v-if="editing && securityConfig.hasReportsRights" class="edit-form container">
           <ReportSummaryForm :hideFormTitle=true
                              :initial-state="model.config"
                              @reportSummarySaved="forwardUpdatedSummary"
@@ -74,7 +75,8 @@ export default {
   },
 
   props: {
-    model: ReportSummaryModel
+    model: ReportSummaryModel,
+    securityConfig: Object
   },
 
   data() {
@@ -111,29 +113,11 @@ export default {
     },
 
     /**
-     * Checks if the user has permission to delete a report summary.
-     * @return true if the user has permission to delete a report summary.
-     */
-    canDelete() {
-      // TODO: implement REDDEV-595
-      return true;
-    },
-
-    /**
      * Emit editSummary event.
      */
     editSummary() {
       this.editing = true;
       // this.$emit('editSummary', this.id);
-    },
-
-    /**
-     * Checks if the user has permission to edit a report summary.
-     * @return true if the user has permission to edit a report summary.
-     */
-    canEdit() {
-      // TODO: implement REDDEV-595
-      return true;
     },
 
     /**

--- a/js/components/ReportSummaryForm.vue
+++ b/js/components/ReportSummaryForm.vue
@@ -281,9 +281,8 @@ export default {
 
     /**
      * Handles rejection of the `saveReportSummary` request.
-     * @param {Error} reason - the error that triggered rejection.
      */
-    handleConfigError(reason) {
+    handleConfigError() {
       this.errors.save = 'An error occurred while trying to save this count.';
     },
 

--- a/js/services/data-service.js
+++ b/js/services/data-service.js
@@ -6,7 +6,8 @@ import ReportSummaryModel from '@/report-summary-model';
 
 export const ENDPOINTS = {
   REPORT_DATA: 'lib/data.php',
-  REPORT_CONFIG: 'lib/settings.php'
+  REPORT_CONFIG: 'lib/settings.php',
+  SECURITY_CONFIG: 'lib/security.php'
 };
 
 /**
@@ -27,6 +28,7 @@ export default function createDataService(assetUrls) {
   return {
     reportDataUrl: assetUrls[ENDPOINTS.REPORT_DATA],
     reportConfigUrl: assetUrls[ENDPOINTS.REPORT_CONFIG],
+    securityConfigUrl: assetUrls[ENDPOINTS.SECURITY_CONFIG],
 
     /**
      * Extracts data returned by the request.
@@ -115,6 +117,16 @@ export default function createDataService(assetUrls) {
      */
     getReportFields(reportId) {
       return this._makeRequest(`${this.reportDataUrl}&action=getReportFields&reportId=${reportId}`);
-    }
+    },
+
+    /**
+     * Fetch security configuration.
+     *
+     * @return {Promise} A promise that resolves to an object with the following keys:
+     *   - hasReportsRights: Boolean indicating whether or not the authenticated user has reports rights.
+     */
+    fetchSecurityConfig() {
+      return this._makeRequest(this.securityConfigUrl);
+    },
   };
 }

--- a/lib/SecurityUtils.php
+++ b/lib/SecurityUtils.php
@@ -1,0 +1,19 @@
+<?php
+namespace Octri\ReportCounts;
+
+/**
+ * A class for handling permissions and other security related operations.
+ */
+class SecurityUtils {
+
+  const REPORTS_RIGHTS = 'reports';
+
+  public static function hasUserRightsFor($permission) {
+    $rights = \REDCap::getUserRights(USERID);
+    return $rights[USERID][$permission];
+  }
+
+  public static function hasReportsRights() {
+    return SUPER_USER || self::hasUserRightsFor(self::REPORTS_RIGHTS);
+  }
+}

--- a/lib/security.php
+++ b/lib/security.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * MODULE: REDCap Report Counts
+ * DESCRIPTION: Get security configuration
+ * RETURNS: Returns security configuration in JSON format.
+ */
+namespace Octri\ReportCounts;
+
+header('Content-Type: application/json');
+
+// Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
+require_once(dirname(realpath(__FILE__)) . '/../../../redcap_connect.php');
+require_once(dirname(realpath(__FILE__)) . '/SecurityUtils.php');
+
+$securityConfig = array(
+    'hasReportsRights' => SecurityUtils::hasReportsRights()
+);
+
+exit(json_encode($securityConfig));


### PR DESCRIPTION
This branch includes work to restrict access for modifying counts.

User based settings permissions are disabled when saving module settings. This allows
all users to save settings if they also have 'Add/Edit/Organize' rights, or are a super user.

Form and summary controls are hidden if the user does not have 'Add/Edit/Organize' rights, or is not a super user.

redcap_module_link_check_display is overridden so that everyone with project access can use the module.