### PR TITLE
REDDEV-617 handle report missing `bucketBy` field

### DIFF
--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -58,6 +58,7 @@ describe('ReportSummary.vue', () => {
         strategy: STRATEGY.ITEMIZED,
         bucketByLabel: 'Field Label',
         bucketByFieldExists: true,
+        bucketByExistsOnReport: true,
         reportExists: true,
         data: [
           'Patient follow-up',
@@ -116,6 +117,7 @@ describe('ReportSummary.vue', () => {
       totalRecords: 8,
       strategy: STRATEGY.ITEMIZED,
       bucketByFieldExists: true,
+      bucketByExistsOnReport: true,
       reportExists: true,
       data: []
     });
@@ -354,7 +356,7 @@ describe('ReportSummary.vue', () => {
     });
   });
 
-  describe('bucketBy field does not exist or has been renamed', () => {
+  describe('bucketBy field error handling', () => {
     let wrapper, model;
 
     beforeEach(() => {
@@ -364,29 +366,59 @@ describe('ReportSummary.vue', () => {
         reportId: 3,
         totalRecords: 8,
         strategy: STRATEGY.ITEMIZED,
-        bucketByFieldExists: false,
         reportExists: true,
         data: []
       });
+    });
 
-      wrapper = mount(ReportSummary, {
-        provide: createProvideObject(),
-        propsData: {
-          model,
-          securityConfig
-        }
+    describe('bucketBy field does not exist', () => {
+      beforeEach(() => {
+        model.bucketByFieldExists = false;
+        model.bucketByExistsOnReport = false;
+        wrapper = mount(ReportSummary, {
+          provide: createProvideObject(),
+          propsData: {
+            model,
+            securityConfig
+          }
+        });
+      });
+
+      it('displays inline error message', () => {
+        expect(wrapper.findAll('[data-description="report-alert"]').length).toEqual(1);
+        expect(wrapper.find('[data-description="report-alert"]').text()).toEqual(messages.missingBucketByField);
+      });
+
+      it('displays title and summary controls', () => {
+        expect(wrapper.findAll('.summary-controls').length).toEqual(1);
+        expect(wrapper.findAll('.card-title').length).toEqual(1);
+        expect(wrapper.find('.card-title').text()).toEqual('Original Title');
       });
     });
 
-    it('displays inline error message', () => {
-      expect(wrapper.findAll('[data-description="report-alert"]').length).toEqual(1);
-      expect(wrapper.find('[data-description="report-alert"]').text()).toEqual(messages.missingBucketByField);
-    });
+    describe('bucketBy field missing from report', () => {
+      beforeEach(() => {
+        model.bucketByFieldExists = true;
+        model.bucketByExistsOnReport = false;
+        wrapper = mount(ReportSummary, {
+          provide: createProvideObject(),
+          propsData: {
+            model,
+            securityConfig
+          }
+        });
+      });
 
-    it('displays title and summary controls', () => {
-      expect(wrapper.findAll('.summary-controls').length).toEqual(1);
-      expect(wrapper.findAll('.card-title').length).toEqual(1);
-      expect(wrapper.find('.card-title').text()).toEqual('Original Title');
+      it('displays inline error message', () => {
+        expect(wrapper.findAll('[data-description="report-alert"]').length).toEqual(1);
+        expect(wrapper.find('[data-description="report-alert"]').text()).toEqual(messages.missingBucketByField);
+      });
+
+      it('displays title and summary controls', () => {
+        expect(wrapper.findAll('.summary-controls').length).toEqual(1);
+        expect(wrapper.findAll('.card-title').length).toEqual(1);
+        expect(wrapper.find('.card-title').text()).toEqual('Original Title');
+      });
     });
   });
 

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -61,7 +61,7 @@ import ReportSummaryForm from './ReportSummaryForm';
 
 export const messages = {
   missingReport: 'The report used for this summary no longer exists.',
-  missingBucketByField: 'The field used to group counts by no longer exists or has been renamed.'
+  missingBucketByField: 'The field used to group counts by no longer exists, has been renamed, or is not present on the report.'
 };
 
 /**
@@ -210,7 +210,7 @@ export default {
      */
     canItemize() {
       const { model } = this;
-      return this.isItemized && model.bucketByFieldExists;
+      return this.isItemized && model.bucketByFieldExists && model.bucketByExistsOnReport;
     },
 
     /**

--- a/js/report-summary-model.js
+++ b/js/report-summary-model.js
@@ -18,7 +18,8 @@ export default class ReportSummaryModel {
       obj.data,
       obj.totalRecords,
       obj.reportExists,
-      obj.bucketByFieldExists
+      obj.bucketByFieldExists,
+      obj.bucketByExistsOnReport
     );
   }
 
@@ -40,9 +41,10 @@ export default class ReportSummaryModel {
    * @param {Boolean} reportExists - `true` if the report exists, otherwise `false` indicating 
    *   the report is inaccessible or deleted.
    * @param {Boolean} bucketByFieldExists = `true` if the field exists, otherwise `false`.
+   * @param {Boolean} bucketByExistsOnReport = `true` if the field is present on the report, otherwise `false`.
    * @return {ReportSummaryModel}
    */
-  constructor(id, title, reportId, strategy, bucketBy, bucketByLabel, data, totalRecords, reportExists, bucketByFieldExists) {
+  constructor(id, title, reportId, strategy, bucketBy, bucketByLabel, data, totalRecords, reportExists, bucketByFieldExists, bucketByExistsOnReport) {
     this.id = id;
     this.title = title;
     this.reportId = reportId;
@@ -53,6 +55,7 @@ export default class ReportSummaryModel {
     this.totalRecords = totalRecords;
     this.reportExists = reportExists;
     this.bucketByFieldExists = bucketByFieldExists;
+    this.bucketByExistsOnReport = bucketByExistsOnReport;
   }
 
   /**

--- a/lib/SummaryUIProcessor.php
+++ b/lib/SummaryUIProcessor.php
@@ -84,6 +84,23 @@ class SummaryUIProcessor {
     }
 
     /**
+     * Get list of fields for a report.
+     */
+    public function getReportFields() {
+        assert(is_array($this->report), 'Must provide valid report data.');
+        assert(count($this->report) > 0, 'The report is empty - must contain records.');
+        return array_keys($this->report[0]);
+    }
+
+    /**
+     * Check if the report has the bucketBy field.
+     */
+    public function reportHasBucketByField() {
+        $reportFields = $this->getReportFields();
+        return in_array($this->summaryConfig['bucketBy'], $reportFields);
+    }
+
+    /**
      * Gets summary config used by the UI for rendering each report 
      * summary (count). If an itemized count is required, include the field
      * label for the field grouped on as well as data used to render itemized
@@ -103,6 +120,7 @@ class SummaryUIProcessor {
 
         if ($this->isItemized()) {
             $this->addItemizedConfig();
+            $this->summaryConfig['bucketByExistsOnReport'] = $this->reportHasBucketByField();
         }
 
         return $this->summaryConfig;

--- a/lib/data.php
+++ b/lib/data.php
@@ -14,6 +14,7 @@ require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 require_once(dirname(realpath(__FILE__)) . '/ReportConfig.php');
 require_once(dirname(realpath(__FILE__)) . '/DataDictionary.php');
 require_once(dirname(realpath(__FILE__)) . '/SummaryUIProcessor.php');
+require_once(dirname(realpath(__FILE__)) . '/ReportStrategy.php');
 
 /**
  * Queries the REDCap database directly to retrieve all the reports for the 
@@ -50,6 +51,37 @@ function reportExists($reportId, $reportsArray) {
    return false;
 }
 
+/**
+ * Get fields for a given report.
+ * @param Integer $reportId The report id
+ * @return Array A list of associative arrays, each with keys: field_name and field_label.
+ */
+function getReportFields($reportId) {
+    $report = json_decode(\REDCap::getReport($reportId, 'json'), true);
+    if (count($report) > 0) {
+        $reportFields = array_keys($report[0]);
+
+        $dictionary = json_decode(\REDCap::getDataDictionary('json'), true);
+
+        $fields = array();
+        foreach ($reportFields as $key=>$field) {
+            foreach ($dictionary as $dictField) {
+                if ($field === $dictField['field_name']
+                        && in_array($dictField['field_type'], array('radio', 'dropdown', 'truefalse', 'yesno'))) {
+                    $fields[] = array(
+                        'field_name' => $dictField['field_name'],
+                        'field_label' => $dictField['field_label']
+                    );
+                }
+            }
+        }
+
+        return $fields;
+    } else {
+        return array();
+    }
+}
+
 if (isset($_GET['action'])) {
     if ($_GET['action'] === 'getReports') {
         $returnArray = getReports();
@@ -58,23 +90,7 @@ if (isset($_GET['action'])) {
         $reportId = intval($_GET['reportId']);
         $report = json_decode(\REDCap::getReport($reportId, 'json'), true);
         if (count($report) > 0) {
-            $reportFields = array_keys($report[0]);
-
-            $dictionary = json_decode(\REDCap::getDataDictionary('json'), true);
-
-            $fields = array();
-            foreach ($reportFields as $key=>$field) {
-                foreach ($dictionary as $dictField) {
-                    if ($field === $dictField['field_name']
-                            && in_array($dictField['field_type'], array('radio', 'dropdown', 'truefalse', 'yesno'))) {
-                        $fields[] = array(
-                            'field_name' => $dictField['field_name'],
-                            'field_label' => $dictField['field_label']
-                        );
-                    }
-                }
-            }
-
+            $fields = getReportFields($reportId);
             exit(json_encode($fields));
         } else {
             exit(json_encode(array()));
@@ -95,8 +111,9 @@ if (isset($_GET['action'])) {
     // Default action, get report config
     $returnArray = array();
     foreach ($config as $summaryConfig) {
-        $report = reportExists($summaryConfig['reportId'], $reportsArray)
-            ? json_decode(\REDCap::getReport($summaryConfig['reportId'], 'json', true /* export labels */), true)
+        $reportId = $summaryConfig['reportId'];
+        $report = reportExists($reportId, $reportsArray)
+            ? json_decode(\REDCap::getReport($reportId, 'json', true /* export labels */), true)
             : null;
         $reportProcessor = new SummaryUIProcessor($summaryConfig, $report, $dataDictionary);
         $returnArray[] = $reportProcessor->summaryConfig();

--- a/tests/SummaryUIProcessorTest.php
+++ b/tests/SummaryUIProcessorTest.php
@@ -94,6 +94,7 @@ final class SummaryUIProcessorTest extends TestCase {
             'reportExists' => true,
             'bucketByLabel' => 'Stop Reason',
             'bucketByFieldExists' => true,
+            'bucketByExistsOnReport' => true,
             'data' => array(
                 'Patient follow-up',
                 'Patient withdrew consent',
@@ -142,6 +143,24 @@ final class SummaryUIProcessorTest extends TestCase {
         $processedSummaryConfig = $reportProcessor->summaryConfig();
 
         $this->assertEquals(false, $processedSummaryConfig['bucketByFieldExists'], 'Bucket by field should not exist');
+    }
+
+    public function testGetReportFields() {
+        $reportProcessor = new SummaryUIProcessor($this->mockItemizedSummaryConfig, $this->mockReport, $this->mockDataDictionary);
+
+        $expectedFields = array('screen_id', 'dsp_stop_reason');
+        $this->assertEquals($expectedFields, $reportProcessor->getReportFields(), 'Report contains the correct fields');
+    }
+
+    public function testReportHasBucketByField() {
+        $reportProcessor = new SummaryUIProcessor($this->mockItemizedSummaryConfig, $this->mockReport, $this->mockDataDictionary);
+        $this->assertTrue($reportProcessor->reportHasBucketByField(), 'Report should contain the bucketBy field');
+    }
+
+    public function testReportIsMissingBucketByField() {
+        $this->mockItemizedSummaryConfig['bucketBy'] = 'this_field_no_present_on_report';
+        $reportProcessor = new SummaryUIProcessor($this->mockItemizedSummaryConfig, $this->mockReport, $this->mockDataDictionary);
+        $this->assertFalse($reportProcessor->reportHasBucketByField(), 'The bucketBy field should not be present on the report');
     }
 
 }


### PR DESCRIPTION
Include boolean in model that indicates whether or not the bucketBy field exists on a given report. If it is not present, render an error message in place of counts.