### PR TITLE
REDDEV-620 updated label for report title

### DIFF
--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -45,7 +45,7 @@ describe('ReportSummary.vue', () => {
       const metadata = wrapper.findAll(selectors.metadata);
       expect(metadata.length).toEqual(2);
       expect(metadata.at(0).text()).toEqual('Total Count: 101');
-      expect(metadata.at(1).text()).toEqual('For Report: Report Title');
+      expect(metadata.at(1).text()).toEqual('Report Name: Report Title');
     });
   });
 
@@ -96,7 +96,7 @@ describe('ReportSummary.vue', () => {
       const metadata = wrapper.findAll(selectors.metadata);
       expect(metadata.length).toEqual(3);
       expect(metadata.at(0).text()).toEqual('Total Count: 6');
-      expect(metadata.at(1).text()).toEqual('For Report: Sample Report Title');
+      expect(metadata.at(1).text()).toEqual('Report Name: Sample Report Title');
       expect(metadata.at(2).text()).toEqual('Grouped By: Field Label');
     });
 

--- a/js/components/ReportSummary.vue
+++ b/js/components/ReportSummary.vue
@@ -32,7 +32,7 @@
         <div v-if="showCounts">
           <ul class="summary-metadata lead list-unstyled mb-0">
             <li>Total Count: {{ model.totalRecords }}</li>
-            <li :title="'Report id: ' + model.reportId">For Report: {{ model.reportTitle }}</li>
+            <li :title="'Report id: ' + model.reportId">Report Name: {{ model.reportTitle }}</li>
             <li v-if="isItemized" class="mt-0">Grouped By: {{ model.bucketByLabel }}</li>
           </ul>
           <ul v-if="isItemized" class="list-unstyled mt-3 mb-0" data-description="itemized-counts">


### PR DESCRIPTION
REDCap internally calls this field title, but in the UI it is generally referred to as report name or name of report. Updating per conversation with Liz.