### PR TITLE
Fix Deprecations in JS Tests

### DIFF
--- a/js-tests/components/ReportCounts_test.js
+++ b/js-tests/components/ReportCounts_test.js
@@ -44,7 +44,7 @@ describe('ReportCounts.vue', () => {
     });
 
     it('has help and instructions', () => {
-      expect(wrapper.find(ReportCountsHelp).exists()).toBe(true);
+      expect(wrapper.findComponent(ReportCountsHelp).exists()).toBe(true);
       // about text should not display when there are summaries
       expect(wrapper.find(aboutTextSelector).exists()).toBe(false);
     });
@@ -103,7 +103,7 @@ describe('ReportCounts.vue', () => {
     });
 
     it('has help and text describing the module', () => {
-      expect(wrapper.find(ReportCountsHelp).exists()).toBe(true);
+      expect(wrapper.findComponent(ReportCountsHelp).exists()).toBe(true);
       expect(wrapper.find(aboutTextSelector).exists()).toBe(true);
     });
 

--- a/js-tests/components/ReportSummaryForm_test.js
+++ b/js-tests/components/ReportSummaryForm_test.js
@@ -171,7 +171,7 @@ describe('ReportSummaryForm.vue', () => {
     expect(wrapper.vm.errorCount).toEqual(1);
     expect(wrapper.vm.errors.bucketBy).toEqual(messages.bucketByRequired);
     expect(wrapper.findAll(`#bucketBy${id}`).length).toEqual(1);
-    expect(wrapper.findAll(`#bucketBy${id}`).isVisible()).toEqual(true);
+    expect(wrapper.findAll(`#bucketBy${id}`).exists()).toEqual(true);
   });
 
   it('checks for fields to group by and displays error message accordingly', async () => {

--- a/js-tests/components/ReportSummary_test.js
+++ b/js-tests/components/ReportSummary_test.js
@@ -219,20 +219,20 @@ describe('ReportSummary.vue', () => {
     });
 
     it('reveals the form when the edit link is clicked', async () => {
-      expect(wrapper.find(ReportSummaryForm).exists()).toBe(false);
+      expect(wrapper.findComponent(ReportSummaryForm).exists()).toBe(false);
       wrapper.find('.edit').trigger('click');
       await Vue.nextTick();
-      expect(wrapper.find(ReportSummaryForm).exists()).toBe(true);
+      expect(wrapper.findComponent(ReportSummaryForm).exists()).toBe(true);
     });
 
     it('closes the form on cancel', async () => {
       wrapper.find('.edit').trigger('click');
       await Vue.nextTick();
-      expect(wrapper.find(ReportSummaryForm).exists()).toBe(true);
+      expect(wrapper.findComponent(ReportSummaryForm).exists()).toBe(true);
 
       wrapper.find('button[type="cancel"]').trigger('click');
       await Vue.nextTick();
-      expect(wrapper.find(ReportSummaryForm).exists()).toBe(false);
+      expect(wrapper.findComponent(ReportSummaryForm).exists()).toBe(false);
     });
 
     it('emits an event when updated config is saved', async () => {
@@ -264,7 +264,7 @@ describe('ReportSummary.vue', () => {
       // allow time for the form's save promise to resolve
       await Promise.resolve();
 
-      expect(wrapper.find(ReportSummaryForm).exists()).toBe(false);
+      expect(wrapper.findComponent(ReportSummaryForm).exists()).toBe(false);
     });
   });
 


### PR DESCRIPTION
Fix deprecation warnings in Vue tests by replacing deprecated uses of `find` and `isVisible` with equivalent calls to `findComponent` and `exists`. Fixes #114.